### PR TITLE
Add num feature to use num create instead of rug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: rust
+rust:
+  - 1.31.0
+  - stable
+  - beta
+  - nightly
+
+script:
+  - cargo test
+  - cargo test --no-default-features --features num

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,12 @@ license = "BSD-3-Clause"
 [dependencies]
 lexical = "2.1.0"
 ordered-float = "0.5.0"
-rug = "1.4.0"
+rug = { optional = true, version = "1.4.0" }
+num-rug-adapter = { optional = true, version = "0.1" }
 
 [lib]
 path = "src/lib.rs"
+
+[features]
+num = ["num-rug-adapter"]
+default = ["rug"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 lexical = "2.1.0"
 ordered-float = "0.5.0"
 rug = { optional = true, version = "1.4.0" }
-num-rug-adapter = { optional = true, version = "0.1" }
+num-rug-adapter = { optional = true, version = "0.1.1" }
 
 [lib]
 path = "src/lib.rs"

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,6 +1,3 @@
-extern crate lexical;
-extern crate rug;
-
 use lexical::parse_lossy;
 use ordered_float::*;
 use rug::Integer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 extern crate lexical;
 extern crate ordered_float;
+#[cfg(feature = "rug")]
 extern crate rug;
+#[cfg(feature = "num-rug-adapter")]
+extern crate num_rug_adapter as rug;
 
 #[macro_use] pub mod tabled_rc;
 #[macro_use] pub mod ast;


### PR DESCRIPTION
This add an feature called num that allow (in a non invasive away) the use the num crate in place of rug (a future PR will be sent to scryer-prolog).

It uses https://github.com/malbarbo/num-rug-adapter crate, that implements parts of rug interface using the num crate. There are two reasons this is interesting. The first one is because of cross compilation. The rug crate does not support cross compilation, the num crate does. So compiling for Android or WebAssembly targets are easy using num crate. The second one is the license. rug, GMP,  MPFR and MPC are LGPL, which make its more difficult to distribute static linked binaries (see https://www.gnu.org/licenses/gpl-faq.html#LGPLStaticVsDynamic).