### PR TITLE
Comment chars

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,4 +12,4 @@ extern crate unicode_reader;
 pub mod parser;
 pub mod put_back_n;
 
-mod lexer;
+pub mod lexer;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -57,6 +57,11 @@ macro_rules! new_line_char {
 }
 
 #[macro_export]
+macro_rules! end_line_comment_char {
+    ($c: expr) => ($c == '%')
+}
+
+#[macro_export]
 macro_rules! comment_1_char {
     ($c: expr) => ($c == '/')
 }

--- a/tests/bom.rs
+++ b/tests/bom.rs
@@ -1,0 +1,46 @@
+extern crate prolog_parser;
+
+use prolog_parser::ast::*;
+use prolog_parser::lexer::{Lexer, Token};
+use prolog_parser::tabled_rc::TabledData;
+
+use std::rc::Rc;
+
+#[test]
+fn valid_token() {
+    let stream = parsing_stream("valid text".as_bytes());
+    assert!(stream.is_ok());
+}
+
+#[test]
+fn empty_stream() {
+    let bytes: &[u8] = &[];
+    match parsing_stream(bytes) {
+        Err(ParserError::UnexpectedEOF) => (),
+        _ => assert!(false)
+    }
+}
+
+#[test]
+fn skip_utf8_bom() {
+    let atom_tbl = TabledData::new(Rc::new("my_module".to_string()));
+    let flags = MachineFlags::default();
+    let bytes: &[u8] = &[0xEF, 0xBB, 0xBF, '4' as u8, '\n' as u8];
+    let mut stream = parsing_stream(bytes).expect("valid stream");
+    let mut lexer = Lexer::new(atom_tbl, flags, &mut stream);
+    match lexer.next_token() {
+        Ok(Token::Constant(Constant::Fixnum(4))) => (),
+        _ => assert!(false)
+    }
+}
+
+#[test]
+fn invalid_utf16_bom() {
+    let bytes: &[u8] = &[0xFF, 0xFE, 'a' as u8, '\n' as u8];
+    let stream = parsing_stream(bytes);
+    match stream {
+        Err(ParserError::Utf8Error(0, 0)) => (),
+        _ => assert!(false)
+    }
+}
+

--- a/tests/parse_comments.rs
+++ b/tests/parse_comments.rs
@@ -1,0 +1,35 @@
+extern crate prolog_parser;
+
+use prolog_parser::ast::*;
+use prolog_parser::lexer::{Lexer, Token};
+use prolog_parser::tabled_rc::TabledData;
+
+use std::rc::Rc;
+
+fn read_all_tokens(text: &str) -> Result<Vec<Token>, ParserError> {
+    let atom_tbl = TabledData::new(Rc::new("my_module".to_string()));
+    let flags = MachineFlags::default();
+    let mut stream = parsing_stream(text.as_bytes());
+    let mut lexer = Lexer::new(atom_tbl, flags, &mut stream);
+
+    let mut tokens = Vec::new();
+    while !lexer.eof()? {
+        let token = lexer.next_token()?;
+        tokens.push(token);
+    }
+    Ok(tokens)
+}
+
+#[test]
+fn empty_multiline_comment() -> Result<(), ParserError> {
+    let tokens = read_all_tokens("/**/ 4\n")?;
+    assert_eq!(tokens, [Token::Constant(Constant::Fixnum(4))]);
+    Ok(())
+}
+
+#[test]
+fn any_char_multiline_comment() -> Result<(), ParserError> {
+    let tokens = read_all_tokens("/* █╗╚═══╝ © */ 4\n")?;
+    assert_eq!(tokens, [Token::Constant(Constant::Fixnum(4))]);
+    Ok(())
+}

--- a/tests/parse_comments.rs
+++ b/tests/parse_comments.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 fn read_all_tokens(text: &str) -> Result<Vec<Token>, ParserError> {
     let atom_tbl = TabledData::new(Rc::new("my_module".to_string()));
     let flags = MachineFlags::default();
-    let mut stream = parsing_stream(text.as_bytes());
+    let mut stream = parsing_stream(text.as_bytes())?;
     let mut lexer = Lexer::new(atom_tbl, flags, &mut stream);
 
     let mut tokens = Vec::new();


### PR DESCRIPTION
This PR does several things:
  0) add integration tests and make lexer public so it can be used there.
  1) make parsing_stream return a Result, because opening a stream now checks that it is valid. This will require modification of scryer-prolog. To be discussed, an alternative design would be to delay checking in entry points of Lexer, but this will incur overhead.
  2) parsing_stream attempts to read one character, to determine if there is a BOM or not. If the stream is empty, we return UnexpectedEOF (optional, we could wait until the lexer). To be discussed, it would be slightly simpler to let the lexer do that, but a bit surprising since this looks like an early check.
  3) if we get an error that is a BadUtf8Error (which should be the case when encountering FF FE or FE FF, those UTF-16 byte sequences are invalid in UTF-8), we map it to the ParserError::Utf8Error, but at this point we could create a more specific BOM error. To be discussed.
  4) if the character is the UTF-8 BOM, we skip it to avoid an error later in the lexer (a BOM, while not recommended by the standard, should be ignored).

Let me know what you think @mthom!