### PR TITLE
Empty stream should not be an error

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -877,7 +877,7 @@ use unicode_reader::BadUtf8Error;
 pub fn parsing_stream<R: Read>(src: R) -> Result<ParsingStream<R>, ParserError> {
     let mut stream = put_back_n(CodePoints::from(src.bytes()));
     match stream.peek() {
-        None => Err(ParserError::UnexpectedEOF),
+        None => Ok(stream), // empty stream is handled gracefully by Lexer::eof
         Some(Err(error)) => Err(ParserError::from(error)),
         Some(Ok(c)) => {
             if *c == '\u{feff}' {

--- a/tests/bom.rs
+++ b/tests/bom.rs
@@ -15,10 +15,7 @@ fn valid_token() {
 #[test]
 fn empty_stream() {
     let bytes: &[u8] = &[];
-    match parsing_stream(bytes) {
-        Err(ParserError::UnexpectedEOF) => (),
-        _ => assert!(false)
-    }
+    assert!(parsing_stream(bytes).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
This was a regression that I introduced by mistake when doing the BOM feature. Fixes #6