### PR TITLE
Fix support of octal and hexadecimal escape sequences + refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prolog_parser"
-version = "0.8.56"
+version = "0.8.57"
 authors = ["Mark Thom <markjordanthom@gmail.com>"]
 repository = "https://github.com/mthom/prolog_parser"
 description = " An operator precedence parser for rusty-wam, an up and coming ISO Prolog implementation."

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -306,7 +306,6 @@ impl<'a, R: Read> Lexer<'a, R> {
             't' => '\t',
             'n' => '\n',
             'r' => '\r',
-            '0' => '\u{0}',
             c   => return Err(ParserError::UnexpectedChar(c, self.line_num, self.col_num))
         };
         self.skip_char()?;

--- a/tests/parse_tokens.rs
+++ b/tests/parse_tokens.rs
@@ -74,8 +74,20 @@ fn char_with_octseq() -> Result<(), ParserError> {
 }
 
 #[test]
+fn char_with_octseq_0() -> Result<(), ParserError> {
+    let tokens = read_all_tokens(r"'\0\' ")?;
+    assert_eq!(tokens, [Token::Constant(Constant::Char('\u{0000}'))]);
+    Ok(())
+}
+
+#[test]
 fn char_with_hexseq() -> Result<(), ParserError> {
     let tokens = read_all_tokens(r"'\x2124\' ")?;
     assert_eq!(tokens, [Token::Constant(Constant::Char('ℤ'))]); // Z math symbol
     Ok(())
+}
+
+#[test]
+fn char_with_hexseq_invalid() {
+    assert!(read_all_tokens(r"'\x\' ").is_err());
 }

--- a/tests/parse_tokens.rs
+++ b/tests/parse_tokens.rs
@@ -42,8 +42,33 @@ fn simple_char() -> Result<(), ParserError> {
 }
 
 #[test]
+fn char_with_meta_seq() -> Result<(), ParserError> {
+    let tokens = read_all_tokens(r#"'\\' '\'' '\"' '\`' "#)?; // use literal string so \ are escaped
+    assert_eq!(tokens, [Token::Constant(Constant::Char('\\')),
+    Token::Constant(Constant::Char('\'')),
+    Token::Constant(Constant::Char('"')),
+    Token::Constant(Constant::Char('`'))]);
+    Ok(())
+}
+
+#[test]
+fn char_with_control_seq() -> Result<(), ParserError> {
+    let tokens = read_all_tokens(r"'\a' '\b' '\r' '\f' '\t' '\n' '\v' ")?;
+    assert_eq!(tokens, [
+        Token::Constant(Constant::Char('\u{07}')),
+        Token::Constant(Constant::Char('\u{08}')),
+        Token::Constant(Constant::Char('\r')),
+        Token::Constant(Constant::Char('\u{0c}')),
+        Token::Constant(Constant::Char('\t')),
+        Token::Constant(Constant::Char('\n')),
+        Token::Constant(Constant::Char('\u{0b}')),
+    ]);
+    Ok(())
+}
+
+#[test]
 fn char_with_octseq() -> Result<(), ParserError> {
-    let tokens = read_all_tokens(r"'\60433\' ")?; // use literal string so \ are escaped
+    let tokens = read_all_tokens(r"'\60433\' ")?;
     assert_eq!(tokens, [Token::Constant(Constant::Char('愛'))]); // Japanese character
     Ok(())
 }

--- a/tests/parse_tokens.rs
+++ b/tests/parse_tokens.rs
@@ -33,3 +33,24 @@ fn any_char_multiline_comment() -> Result<(), ParserError> {
     assert_eq!(tokens, [Token::Constant(Constant::Fixnum(4))]);
     Ok(())
 }
+
+#[test]
+fn simple_char() -> Result<(), ParserError> {
+    let tokens = read_all_tokens("'a'\n")?;
+    assert_eq!(tokens, [Token::Constant(Constant::Char('a'))]);
+    Ok(())
+}
+
+#[test]
+fn char_with_octseq() -> Result<(), ParserError> {
+    let tokens = read_all_tokens(r"'\60433\' ")?; // use literal string so \ are escaped
+    assert_eq!(tokens, [Token::Constant(Constant::Char('愛'))]); // Japanese character
+    Ok(())
+}
+
+#[test]
+fn char_with_hexseq() -> Result<(), ParserError> {
+    let tokens = read_all_tokens(r"'\x2124\' ")?;
+    assert_eq!(tokens, [Token::Constant(Constant::Char('ℤ'))]); // Z math symbol
+    Ok(())
+}


### PR DESCRIPTION
Ok this ended up a bit bigger than anticipated :smile: 

The fix is actually quite easy: the numbers were converted to u8, so any constant larger than that would raise an error. Instead I moved to u32 which should be enough to represent any Unicode character ever. I replaced rug Integer by u32 directly as a result.

While exploring the code, I noticed that the lexer would keep eating the backslash and then return it. So instead, I replaced this with an early exit if we don't have a backslash, and all sequences no longer have to check for that. Then it is only a matter of returning an option instead of an error if the lookahead char is not the right one for any given method. In theory you could even go further and do a single `match self.lookahead_char()?` to determine which sequence is the right one, but unfortunately I only just thought of that while writing this :smiley:

I added a few unit tests for normal character, and octal and hexadecimal escape sequences. Ideally we should add a few more for continuation escape sequences, as well as meta and control.