### PR TITLE
Fix parsing a line comment then EOF

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -128,7 +128,7 @@ impl<'a, R: Read> Lexer<'a, R> {
     fn single_line_comment(&mut self) -> Result<(), ParserError>
     {
         loop {
-            if new_line_char!(self.skip_char()?) {
+            if self.eof()? || new_line_char!(self.skip_char()?) {
                 break;
             }
         }
@@ -872,6 +872,7 @@ impl<'a, R: Read> Lexer<'a, R> {
 
                 self.name_token(c)
             },
+            Err(ParserError::UnexpectedEOF) => Ok(Token::End),
             Err(e) => Err(e)
         }
     }

--- a/tests/parse_tokens.rs
+++ b/tests/parse_tokens.rs
@@ -91,3 +91,17 @@ fn char_with_hexseq() -> Result<(), ParserError> {
 fn char_with_hexseq_invalid() {
     assert!(read_all_tokens(r"'\x\' ").is_err());
 }
+
+#[test]
+fn empty() -> Result<(), ParserError> {
+    let tokens = read_all_tokens("")?;
+    assert!(tokens.is_empty());
+    Ok(())
+}
+
+#[test]
+fn comment_then_eof() -> Result<(), ParserError> {
+    let tokens = read_all_tokens("% only a comment")?;
+    assert_eq!(tokens, [Token::End]);
+    Ok(())
+}


### PR DESCRIPTION
Fixes [this issue](https://github.com/mthom/scryer-prolog/issues/550) from `scryer-prolog`.

There's a bit of an inconsistency now: parsing a completely empty file returns an empty vector of tokens, parsing a file with only a comment will return a vector with only `Token::End`. Not sure if this is a problem or not.